### PR TITLE
fix: return only items that matches exactly to the search params

### DIFF
--- a/src/modules/predicate/services.ts
+++ b/src/modules/predicate/services.ts
@@ -86,19 +86,18 @@ export class PredicateService implements IPredicateService {
     };
 
     this._filter.address &&
-      queryBuilder.where(
-        'LOWER(p.predicatedAddress) LIKE LOWER(:predicatedAddress)',
-        { predicateAddress: `%${this._filter.address}%` },
-      );
+      queryBuilder.where('LOWER(p.predicateAddress) = LOWER(:predicateAddress)', {
+        predicateAddress: this._filter.address.toLowerCase(),
+      });
 
     this._filter.provider &&
-      queryBuilder.where('LOWER(p.provider) LIKE LOWER(:provider)', {
-        provider: `%${this._filter.provider}%`,
+      queryBuilder.where('LOWER(p.provider) = LOWER(:provider)', {
+        provider: `${this._filter.provider}`,
       });
 
     this._filter.owner &&
-      queryBuilder.where('LOWER(p.owner) LIKE LOWER(:owner)', {
-        owner: `%${this._filter.owner}%`,
+      queryBuilder.where('LOWER(p.owner) = LOWER(:owner)', {
+        owner: `${this._filter.owner}`,
       });
 
     this._filter.signer &&


### PR DESCRIPTION
Evita que sejam retornados registros que não sejam exatamente iguais aos parametros da query.