### PR TITLE
fix: add validation and return error if no predicate is found

### DIFF
--- a/src/modules/predicate/services.ts
+++ b/src/modules/predicate/services.ts
@@ -66,6 +66,8 @@ export class PredicateService implements IPredicateService {
         return predicate;
       })
       .catch(e => {
+        if (e instanceof GeneralError) throw e;
+
         throw new Internal({
           type: ErrorTypes.Internal,
           title: 'Error on predicate findById',

--- a/src/modules/predicate/validations.ts
+++ b/src/modules/predicate/validations.ts
@@ -7,7 +7,7 @@ export const validateAddPredicatePayload = validator.body(
     name: Joi.string().required(),
     predicateAddress: Joi.string().required(),
     description: Joi.string().allow(''),
-    minSigners: Joi.number().strict(true).min(1).required(),
+    minSigners: Joi.number().strict(true).integer().min(1).required(),
     addresses: Joi.array().items(Joi.string()).min(1).required(),
     owner: Joi.string().required(),
     bytes: Joi.string().required(),


### PR DESCRIPTION
Validando os testes dos predicados achei necessário fazer esses dois ajustes:

- Validar se minSigners é um número inteiro
- Retornar erro 404 se a busca do predicado pelo id não retornar nenhum registro