### PR TITLE
[FIX]: Filter Transactions By Id

### DIFF
--- a/src/modules/predicate/controller.ts
+++ b/src/modules/predicate/controller.ts
@@ -161,7 +161,7 @@ export class PredicateController {
 
   async hasReservedCoins({ params: { address } }: IFindByHashRequest) {
     try {
-      console.log('[HAS_RESERVED_COINS]: ');
+      // console.log('[HAS_RESERVED_COINS]: ');
       //console.log('[HAS_RESERVED_COINS]: ', address);
       const response = await this.transactionService
         .filter({

--- a/src/modules/transaction/controller.ts
+++ b/src/modules/transaction/controller.ts
@@ -446,6 +446,7 @@ export class TransactionController {
         createdBy,
         predicateId,
         name,
+        id,
       } = req.query;
       const { workspace, user } = req;
 
@@ -468,6 +469,7 @@ export class TransactionController {
 
       const result = await new TransactionService()
         .filter({
+          id,
           to,
           status: status ?? undefined,
           createdBy,


### PR DESCRIPTION
**O que foi feito:**

- Foi adicionado o `ID` na `req.query` para retiramos o id da transaction recebido no front e passado para o filtro.