### PR TITLE
fix(webauthn): returns user data only if user is found by public key

### DIFF
--- a/src/utils/token/web3.ts
+++ b/src/utils/token/web3.ts
@@ -24,7 +24,9 @@ export const recoverWebAuthnSignature = async (
         [addr],
       ).then(response => !!response[0] && response[0].address);
 
-      return user;
+      if (user) {
+        return user;
+      }
     } catch (e) {
       continue;
     }


### PR DESCRIPTION
- Da forma que a lógica estava antes nunca passava da primeira iteração do for, o que acabava gerando erro quando o recovery bit era 1. Foi alterada a lógica para retornar dados do usuário apenas se for encontrado.

https://app.clickup.com/t/86a2pdtm1