### PR TITLE
CHORE: Use toLocaleString to format vault balance usd

### DIFF
--- a/packages/api/src/utils/balance.ts
+++ b/packages/api/src/utils/balance.ts
@@ -54,7 +54,10 @@ const calculateBalanceUSD = async (
     balanceUSD += parseFloat(formattedAmount) * priceUSD;
   });
 
-  return balanceUSD.toFixed(2);
+  return balanceUSD.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
 };
 
 const subCoins = (


### PR DESCRIPTION
https://app.clickup.com/t/86a596dwq

apply the same logic used in the usd tx amount on tx card from this PR: https://github.com/infinitybase/bako-safe-ui/pull/533