### PR TITLE
CHORE: Add depoist name generator

### DIFF
--- a/packages/api/src/modules/transaction/utils.ts
+++ b/packages/api/src/modules/transaction/utils.ts
@@ -31,6 +31,15 @@ export const formatTransactionsResponse = (
   }
 };
 
+export const generateDepositName = () => {
+  let depositName = 'Deposit #';
+  for (let i = 0; i < 5; i++) {
+    const randomInt = Math.floor(Math.random() * 10);
+    depositName += randomInt.toString();
+  }
+  return depositName;
+};
+
 export const formatFuelTransaction = async (
   tx: TransactionResult,
   predicate: Predicate,
@@ -53,7 +62,7 @@ export const formatFuelTransaction = async (
 
   const formattedTransaction = {
     id: tx.id,
-    name: `DEPOSIT_${tx.id}`, // TODO: change this
+    name: generateDepositName(),
     hash: tx.id.slice(2),
     sendTime: tx.date,
     createdAt: tx.date,

--- a/packages/api/src/modules/transaction/utils.ts
+++ b/packages/api/src/modules/transaction/utils.ts
@@ -62,7 +62,7 @@ export const formatFuelTransaction = async (
 
   const formattedTransaction = {
     id: tx.id,
-    name: generateDepositName(),
+    name: 'Deposit',
     hash: tx.id.slice(2),
     sendTime: tx.date,
     createdAt: tx.date,

--- a/packages/api/src/modules/transaction/utils.ts
+++ b/packages/api/src/modules/transaction/utils.ts
@@ -31,15 +31,6 @@ export const formatTransactionsResponse = (
   }
 };
 
-export const generateDepositName = () => {
-  let depositName = 'Deposit #';
-  for (let i = 0; i < 5; i++) {
-    const randomInt = Math.floor(Math.random() * 10);
-    depositName += randomInt.toString();
-  }
-  return depositName;
-};
-
 export const formatFuelTransaction = async (
   tx: TransactionResult,
   predicate: Predicate,


### PR DESCRIPTION
https://app.clickup.com/t/86a4vqnju

Instead of use the same logic in the UI `Deposit# + 5 random numbers` we'll only use `Depoist` to avoid random names for the same Deposit

this task is a complement to this one: https://github.com/infinitybase/bako-safe-ui/pull/542