### PR TITLE
CHORE: Add handle_info column to address book to help show correct handle on front

### DIFF
--- a/packages/api/src/database/migrations/1732301542890-add-handle-infos-column-to-adb.ts
+++ b/packages/api/src/database/migrations/1732301542890-add-handle-infos-column-to-adb.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddHandleInfosColumnToAdb1732301542890 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'address_book',
+      new TableColumn({
+        name: 'handle_info',
+        type: 'jsonb',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('address_book', 'handle_info');
+  }
+}

--- a/packages/api/src/models/AddressBook.ts
+++ b/packages/api/src/models/AddressBook.ts
@@ -9,6 +9,11 @@ export enum AddressBookType {
   WORKSPACE = 'WORKSPACE',
 }
 
+export type IHandleInfo = {
+  handle?: string;
+  resolver?: string;
+};
+
 @Entity('address_book')
 class AddressBook extends Base {
   @Column({ unique: true })
@@ -21,6 +26,13 @@ class AddressBook extends Base {
   @JoinColumn({ name: 'user_id' })
   @OneToOne(() => User)
   user: User;
+
+  @Column({
+    type: 'jsonb',
+    name: 'handle_info',
+    nullable: true,
+  })
+  handle_info: IHandleInfo;
 }
 
 export default AddressBook;

--- a/packages/api/src/modules/addressBook/controller.ts
+++ b/packages/api/src/modules/addressBook/controller.ts
@@ -31,7 +31,7 @@ export class AddressBookController {
 
   async create(req: ICreateAddressBookRequest) {
     try {
-      const { address, nickname } = req.body;
+      const { address, nickname, resolver, handle } = req.body;
       const { workspace, network } = req;
       const duplicatedNickname = await new AddressBookService()
         .filter({
@@ -74,6 +74,10 @@ export class AddressBookController {
 
       const newContact = await this.addressBookService.create({
         ...req.body,
+        handle_info: {
+          handle,
+          resolver,
+        },
         user: savedUser,
         owner: workspace,
       });

--- a/packages/api/src/modules/addressBook/services.ts
+++ b/packages/api/src/modules/addressBook/services.ts
@@ -51,7 +51,7 @@ export class AddressBookService implements IAddressBookService {
     const hasPagination = this._pagination?.page && this._pagination?.perPage;
     const hasOrdination = this._ordination?.orderBy && this._ordination?.sort;
     const queryBuilder = AddressBook.createQueryBuilder('ab')
-      .select(['ab.id', 'ab.nickname'])
+      .select(['ab.id', 'ab.nickname', 'ab.handle_info'])
       .innerJoin('ab.user', 'user')
       .innerJoin('ab.owner', 'owner')
       .addSelect([
@@ -158,7 +158,7 @@ export class AddressBookService implements IAddressBookService {
 
   async findById(id: string): Promise<AddressBook> {
     const queryBuilder = AddressBook.createQueryBuilder('ab')
-      .select(['ab.id', 'ab.nickname'])
+      .select(['ab.id', 'ab.nickname', 'ab.handle_info'])
       .innerJoin('ab.user', 'user')
       .innerJoin('ab.owner', 'owner')
       .addSelect(['user.id', 'user.address'])

--- a/packages/api/src/modules/addressBook/types.ts
+++ b/packages/api/src/modules/addressBook/types.ts
@@ -22,6 +22,12 @@ export enum Sort {
 export interface ICreateAddressBookPayload {
   nickname: string;
   address: string;
+  handle?: string;
+  resolver?: string;
+  handle_info?: {
+    handle?: string;
+    resolver?: string;
+  };
   user: User;
   owner: Workspace;
 }

--- a/packages/api/src/modules/addressBook/validations.ts
+++ b/packages/api/src/modules/addressBook/validations.ts
@@ -6,6 +6,8 @@ export const validateCreateAddressBookPayload = validator.body(
   Joi.object({
     nickname: Joi.string().required(),
     address: Joi.string().required().custom(AddressValidator.validate),
+    handle: Joi.string().optional(),
+    resolver: Joi.string().optional(),
   }),
 );
 
@@ -14,5 +16,9 @@ export const validateUpdateAddressBookPayload = validator.body(
     id: Joi.string().required(),
     nickname: Joi.string().required(),
     address: Joi.string().required().custom(AddressValidator.validate),
+    handle_info: Joi.object({
+      handle: Joi.string().optional(),
+      resolver: Joi.string().optional(),
+    }).optional(),
   }),
 );

--- a/packages/api/src/modules/transaction/controller.ts
+++ b/packages/api/src/modules/transaction/controller.ts
@@ -1,5 +1,4 @@
 import { TransactionStatus, TransactionType, WitnessStatus } from 'bakosafe';
-import { Provider } from 'fuels';
 import { isUUID } from 'class-validator';
 import { PermissionRoles, Workspace } from '@src/models/Workspace';
 import {
@@ -136,7 +135,7 @@ export class TransactionController {
     workspace,
     network,
   }: ICreateTransactionRequest) {
-    const { predicateAddress, summary, hash } = transaction;
+    const { predicateAddress, summary, hash, handle, resolver } = transaction;
 
     try {
       const existsTx = await Transaction.findOne({
@@ -189,6 +188,8 @@ export class TransactionController {
         type: Transaction.getTypeFromTransactionRequest(transaction.txData),
         status: TransactionStatus.AWAIT_REQUIREMENTS,
         resume: {
+          handle,
+          resolver,
           hash: transaction.hash,
           status: TransactionStatus.AWAIT_REQUIREMENTS,
           witnesses,

--- a/packages/api/src/modules/transaction/types.ts
+++ b/packages/api/src/modules/transaction/types.ts
@@ -46,6 +46,8 @@ export interface ITransactionResponse extends Transaction {
 
 export interface ICreateTransactionPayload {
   name: string;
+  handle?: string;
+  resolver?: string;
   hash: string;
   predicateAddress: string;
   status: TransactionStatus;

--- a/packages/api/src/modules/transaction/validations.ts
+++ b/packages/api/src/modules/transaction/validations.ts
@@ -14,6 +14,8 @@ export const validateAddTransactionPayload = validator.body(
     status: Joi.string()
       .required()
       .valid(...allowedStatus),
+    handle: Joi.string().optional(),
+    resolver: Joi.string().optional(),
     sendTime: Joi.string().optional(),
     gasUsed: Joi.string().optional(),
     resume: Joi.string().optional(),


### PR DESCRIPTION
https://app.clickup.com/t/86a5mq4r5

this pr is a complement to: https://github.com/infinitybase/bako-safe-ui/pull/561

 I've forgot to mention in the commit: I also added the "handle" and "resolver" fields to transaction resume, because without saving it we can't show the correct handle in the transaction breakdown. Without this, it always show the primary handle.