### PR TITLE
fix(transactions): add transaction operations on creation

### DIFF
--- a/packages/api/src/modules/transaction/controller.ts
+++ b/packages/api/src/modules/transaction/controller.ts
@@ -220,7 +220,7 @@ export class TransactionController {
         },
         predicate,
         createdBy: user,
-        summary: summary || {
+        summary: summary ?? {
           type: 'cli',
           operations,
         },

--- a/packages/api/src/modules/transaction/controller.ts
+++ b/packages/api/src/modules/transaction/controller.ts
@@ -14,6 +14,7 @@ import { IPredicateService } from '@modules/predicate/types';
 import { BadRequest, error, ErrorTypes, NotFound } from '@utils/error';
 import {
   bindMethods,
+  FuelProvider,
   generateWitnessesUpdatedAt,
   Responses,
   successful,
@@ -43,7 +44,12 @@ import {
 import { createTxHistoryEvent, mergeTransactionLists } from './utils';
 import { In, Not } from 'typeorm';
 import { NotificationService } from '../notification/services';
-import { Address } from 'fuels';
+import {
+  Address,
+  getTransactionSummary,
+  getTransactionSummaryFromRequest,
+  transactionRequestify,
+} from 'fuels';
 
 // todo: use this provider by session, and move to transactions
 const { FUEL_PROVIDER } = process.env;
@@ -192,6 +198,10 @@ export class TransactionController {
 
       const config = JSON.parse(predicate.configurable);
 
+      const { operations } = await getTransactionSummaryFromRequest({
+        transactionRequest: transactionRequestify(transaction.txData),
+        provider: await FuelProvider.create(network.url),
+      });
       const newTransaction = await this.transactionService.create({
         ...transaction,
         type: Transaction.getTypeFromTransactionRequest(transaction.txData),
@@ -210,7 +220,10 @@ export class TransactionController {
         },
         predicate,
         createdBy: user,
-        summary,
+        summary: summary || {
+          type: 'cli',
+          operations,
+        },
         network,
       });
 

--- a/packages/api/src/modules/transaction/utils.ts
+++ b/packages/api/src/modules/transaction/utils.ts
@@ -99,10 +99,7 @@ export const formatFuelTransaction = async (
         single: predicate.workspace.single,
       },
     },
-    assets: formatAssets(
-      outputs,
-      predicate.predicateAddress,
-    ),
+    assets: formatAssets(outputs, predicate.predicateAddress),
     network: {
       url: provider.url,
       chainId,

--- a/packages/api/src/utils/formatAssets.ts
+++ b/packages/api/src/utils/formatAssets.ts
@@ -1,14 +1,14 @@
-import { bn, OutputCoin, TransactionRequestOutput } from 'fuels';
-import { isOutputCoin } from './outputTypeValidate';
+import { OutputCoin, OutputType, TransactionRequestOutput } from 'fuels';
 
 const { FUEL_PROVIDER_CHAIN_ID } = process.env;
 
-const formatAssets = (
-  outputs: TransactionRequestOutput[],
-  to?: string,
-) => {
+const formatAssets = (outputs: TransactionRequestOutput[], to?: string) => {
   const assets = outputs
-    .filter((output: TransactionRequestOutput) => isOutputCoin(output))
+    .filter(
+      (output: TransactionRequestOutput) =>
+        output.type === OutputType.Coin || output.type === OutputType.Variable,
+    )
+    .filter((output: OutputCoin) => !!output.to && !!output.amount)
     .filter((output: OutputCoin) => (to ? output.to === to : true))
     .map((output: OutputCoin) => {
       const { assetId, amount, to } = output;


### PR DESCRIPTION
## Description
When the transaction is sent to server without summary the operations not display correctly.

## Summary
- [x] Fetch the operations in server before store the transaction