### PR TITLE
fix(address-book): change to return duplicated error field in title

### DIFF
--- a/packages/api/src/modules/addressBook/controller.ts
+++ b/packages/api/src/modules/addressBook/controller.ts
@@ -51,11 +51,12 @@ export class AddressBookController {
         .then((response: AddressBook[]) => response.length > 0);
 
       const hasDuplicate = duplicatedNickname || duplicatedAddress;
+      const fieldError = duplicatedNickname ? 'nickname' : 'address';
 
       if (hasDuplicate) {
         throw new Internal({
           type: ErrorTypes.Internal,
-          title: 'Error on contact creation',
+          title: `Error on contact creation - ${fieldError} duplicated`,
           detail: `Duplicated ${duplicatedNickname ? 'nickname' : 'address'}`,
         });
       }


### PR DESCRIPTION
# Description
Addressbook register was not displaying errors by duplicate field in form

# Summary
 - [x] Change to send the field with duplicated error in title information

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
