### PR TITLE
feat: implement redis adapter

### DIFF
--- a/packages/socket-server/docker-compose.yml
+++ b/packages/socket-server/docker-compose.yml
@@ -1,24 +1,26 @@
 version: '3'
 services:
-  api:
-    container_name: ${SOCKET_NAME}
-    ports:
-      - '${PORT}:${PORT}'
-    build:
-      dockerfile: Dockerfile
-      context: .
-    working_dir: /socket
-    environment:
-      # DATABASE
-      - DATABASE_HOST=${DATABASE_HOST}
-      - DATABASE_PORT=${DATABASE_PORT}
-      - DATABASE_USERNAME=${DATABASE_USERNAME}
-      - DATABASE_PASSWORD=${DATABASE_PASSWORD}
-      - DATABASE_NAME=${DATABASE_NAME}
-      # ASSETS
-      - UI_URL=${UI_URL}
-      - API_URL=${API_URL}
-      # APP
-      - SOCKET_PORT=${SOCKET_PORT}
-      - SOCKET_NAME=${SOCKET_NAME}
-      - SOCKET_TIMEOUT_DICONNECT=${SOCKET_TIMEOUT_DICONNECT}
+ api:
+  container_name: ${SOCKET_NAME}
+  ports:
+   - '${PORT}:${PORT}'
+  build:
+   dockerfile: Dockerfile
+   context: .
+  working_dir: /socket
+  environment:
+   # DATABASE
+   - DATABASE_HOST=${DATABASE_HOST}
+   - DATABASE_PORT=${DATABASE_PORT}
+   - DATABASE_USERNAME=${DATABASE_USERNAME}
+   - DATABASE_PASSWORD=${DATABASE_PASSWORD}
+   - DATABASE_NAME=${DATABASE_NAME}
+   # ASSETS
+   - UI_URL=${UI_URL}
+   - API_URL=${API_URL}
+   # APP
+   - SOCKET_PORT=${SOCKET_PORT}
+   - SOCKET_NAME=${SOCKET_NAME}
+   - SOCKET_TIMEOUT_DICONNECT=${SOCKET_TIMEOUT_DICONNECT}
+   - REDIS_URL_READ=${REDIS_URL_READ}
+   - REDIS_URL_WRITE=${REDIS_URL_WRITE}

--- a/packages/socket-server/package.json
+++ b/packages/socket-server/package.json
@@ -12,11 +12,13 @@
 	},
 	"keywords": [],
 	"dependencies": {
+		"@socket.io/redis-adapter": "^8.3.0",
 		"axios": "1.5.1",
 		"bakosafe": "0.1.8",
 		"express": "4.17.1",
 		"express-joi-validation": "5.0.0",
 		"fuels": "0.99.0",
+		"ioredis": "^5.4.1",
 		"pg": "8.5.1",
 		"socket.io": "4.7.2",
 		"ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,7 +191,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.3
-        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@20.6.0)(ts-node@10.9.2(@types/node@20.6.0)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.24.0)(jest@29.7.0(@types/node@20.6.0)(ts-node@10.9.2(@types/node@20.6.0)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node-dev:
         specifier: 1.1.6
         version: 1.1.6(typescript@5.4.5)
@@ -221,6 +221,9 @@ importers:
 
   packages/socket-server:
     dependencies:
+      '@socket.io/redis-adapter':
+        specifier: ^8.3.0
+        version: 8.3.0(socket.io-adapter@2.5.5)
       axios:
         specifier: 1.5.1
         version: 1.5.1
@@ -236,6 +239,9 @@ importers:
       fuels:
         specifier: 0.99.0
         version: 0.99.0(vitest@2.0.5(@types/node@20.6.0))
+      ioredis:
+        specifier: ^5.4.1
+        version: 5.4.1
       pg:
         specifier: 8.5.1
         version: 8.5.1
@@ -320,7 +326,7 @@ importers:
         version: 6.1.3
       ts-jest:
         specifier: ^29.1.3
-        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@20.6.0)(ts-node@10.9.2(@types/node@20.6.0)(typescript@5.4.5)))(typescript@5.4.5)
+        version: 29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.24.0)(jest@29.7.0(@types/node@20.6.0)(ts-node@10.9.2(@types/node@20.6.0)(typescript@5.4.5)))(typescript@5.4.5)
       ts-node-dev:
         specifier: 1.1.6
         version: 1.1.6(typescript@5.4.5)
@@ -1690,6 +1696,12 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@socket.io/redis-adapter@8.3.0':
+    resolution: {integrity: sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      socket.io-adapter: ^2.5.4
+
   '@sqltools/formatter@1.2.5':
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
 
@@ -2240,6 +2252,7 @@ packages:
   bson@6.10.1:
     resolution: {integrity: sha512-P92xmHDQjSKPLHqFxefqMxASNq/aWJMEZugpCjf+AF/pgcUpMMQCg7t7+ewko0/u8AapvF3luf/FoehddEK+sA==}
     engines: {node: '>=16.20.1'}
+    deprecated: a critical bug affecting only useBigInt64=true deserialization usage is fixed in bson@6.10.3
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -4133,6 +4146,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  notepack.io@3.0.1:
+    resolution: {integrity: sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -5439,6 +5455,10 @@ packages:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  uid2@1.0.0:
+    resolution: {integrity: sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==}
+    engines: {node: '>= 4.0.0'}
 
   union-value@1.0.1:
     resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
@@ -7173,6 +7193,15 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@socket.io/component-emitter@3.1.2': {}
+
+  '@socket.io/redis-adapter@8.3.0(socket.io-adapter@2.5.5)':
+    dependencies:
+      debug: 4.3.7
+      notepack.io: 3.0.1
+      socket.io-adapter: 2.5.5
+      uid2: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@sqltools/formatter@1.2.5': {}
 
@@ -10145,6 +10174,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  notepack.io@3.0.1: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -11214,7 +11245,7 @@ snapshots:
     dependencies:
       typescript: 5.4.5
 
-  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(jest@29.7.0(@types/node@20.6.0)(ts-node@10.9.2(@types/node@20.6.0)(typescript@5.4.5)))(typescript@5.4.5):
+  ts-jest@29.2.5(@babel/core@7.25.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.7))(esbuild@0.24.0)(jest@29.7.0(@types/node@20.6.0)(ts-node@10.9.2(@types/node@20.6.0)(typescript@5.4.5)))(typescript@5.4.5):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -11232,6 +11263,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.25.7)
+      esbuild: 0.24.0
 
   ts-node-dev@1.1.6(typescript@5.4.5):
     dependencies:
@@ -11379,6 +11411,8 @@ snapshots:
   typescript@5.4.5: {}
 
   uglify-js@3.19.3: {}
+
+  uid2@1.0.0: {}
 
   union-value@1.0.1:
     dependencies:


### PR DESCRIPTION
# Description
This PR aims to enable the operation of parallel instances for the socket through the load balancer.

# Summary
Added the packages @socket.io/redis-adapter and ioredis, which are used to create an adapter for managing messages passing through the socket and ensuring that instances do not process events in a duplicated manner.

