### PR TITLE
fix(pagination): adjust to start from page 1 and correct skip calcula…

### DIFF
--- a/packages/api/src/modules/user/controller.ts
+++ b/packages/api/src/modules/user/controller.ts
@@ -6,14 +6,18 @@ import { bindMethods } from '@src/utils/bindMethods';
 
 import {
   BadRequest,
+  error,
   ErrorTypes,
   Unauthorized,
   UnauthorizedErrorTitles,
-  error,
 } from '@utils/error';
 import { IconUtils } from '@utils/icons';
 import { Responses, successful, TokenUtils } from '@utils/index';
 
+import App from '@src/server/app';
+import { FuelProvider } from '@src/utils/FuelProvider';
+import { Not } from 'typeorm';
+import { IChangenetworkRequest } from '../auth/types';
 import { PredicateService } from '../predicate/services';
 import { RecoverCodeService } from '../recoverCode/services';
 import { TransactionService } from '../transaction/services';
@@ -31,10 +35,6 @@ import {
   IUpdateRequest,
   IUserService,
 } from './types';
-import { Not } from 'typeorm';
-import App from '@src/server/app';
-import { IChangenetworkRequest } from '../auth/types';
-import { FuelProvider } from '@src/utils/FuelProvider';
 
 export class UserController {
   private userService: IUserService;
@@ -91,7 +91,7 @@ export class UserController {
           signer: hasSingle ? user.address : undefined,
           network: network.url,
         })
-        .paginate({ page: '0', perPage: '6' })
+        .paginate({ page: '1', perPage: '6' })
         .ordination({ orderBy: 'createdAt', sort: 'DESC' })
         .list();
 
@@ -146,7 +146,7 @@ export class UserController {
           workspace: workspaceList,
           signer: hasSingle ? user.address : undefined,
         })
-        .paginate({ page: '0', perPage: '8' })
+        .paginate({ page: '1', perPage: '8' })
         .ordination({ orderBy: 'updatedAt', sort: 'DESC' })
         .list();
 

--- a/packages/api/src/utils/pagination/pagination.ts
+++ b/packages/api/src/utils/pagination/pagination.ts
@@ -10,11 +10,11 @@ export class Pagination<T> {
   }
 
   async paginate(params: PaginationParams): Promise<IPagination<T>> {
-    const currentPage = Number(params.page || 0);
+    const currentPage = Number(params.page || 1); // Adjust first page to 1
     const perPage = Number(params.perPage || 10);
 
     const take = perPage;
-    const skip = currentPage * perPage;
+    const skip = (currentPage - 1) * perPage; // Adjust skip calculation
 
     const data = await this._queryBuilder.take(take).skip(skip).getMany();
     const total = await this._queryBuilder.getCount();

--- a/packages/api/src/utils/pagination/pagination.ts
+++ b/packages/api/src/utils/pagination/pagination.ts
@@ -10,11 +10,11 @@ export class Pagination<T> {
   }
 
   async paginate(params: PaginationParams): Promise<IPagination<T>> {
-    const currentPage = Number(params.page || 1); // Adjust first page to 1
+    const currentPage = Number(params.page || 1);
     const perPage = Number(params.perPage || 10);
 
     const take = perPage;
-    const skip = (currentPage - 1) * perPage; // Adjust skip calculation
+    const skip = (currentPage - 1) * perPage;
 
     const data = await this._queryBuilder.take(take).skip(skip).getMany();
     const total = await this._queryBuilder.getCount();


### PR DESCRIPTION
# Description
Keeping 0 as the first page causes problems when trying to calculate the `totalPages`, for example: if we have a list with 10 items and we list 5 per page, the pagination response would be something like:
```ts
{
  currentPage: 0
  totalPages: 2
}
```

causing the frontend to make 3 requests (page: 0, 1, 2)

# Summary
 - [x] Adjust pagination to use 1 as first page

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
