### PR TITLE
fix(predicates): add hidden false in list home predicates

### DIFF
--- a/packages/api/src/modules/user/controller.ts
+++ b/packages/api/src/modules/user/controller.ts
@@ -141,24 +141,22 @@ export class UserController {
         workspace,
         user,
       );
-      const hidden = false;
+
       const predicates = await new PredicateService()
         .filter({
           workspace: workspaceList,
           signer: hasSingle ? user.address : undefined,
-          hidden,
+          hidden: false,
           userId: user.id,
         })
         .paginate({ page: '0', perPage: '8' })
         .ordination({ orderBy: 'updatedAt', sort: 'DESC' })
         .list();
 
-      const addHiddenFlag = (vault: Predicate): PredicateWithHidden => {
-        return {
-          ...vault,
-          isHidden: vault.isHiddenForUser(user),
-        };
-      };
+      const addHiddenFlag = (vault: Predicate): PredicateWithHidden => ({
+        ...vault,
+        isHidden: vault.isHiddenForUser(user),
+      });
 
       let processedResponse;
 
@@ -166,13 +164,13 @@ export class UserController {
         const enhancedData = predicates.data.map(addHiddenFlag);
         processedResponse = {
           ...predicates,
-          data: enhancedData.filter(vault => (hidden ? true : !vault.isHidden)),
+          data: enhancedData,
         };
       } else {
         const enhancedData = predicates.map(addHiddenFlag);
         processedResponse = {
           ...predicates,
-          data: enhancedData.filter(vault => (predicates ? true : !vault.isHidden)),
+          data: enhancedData,
         };
       }
 

--- a/packages/api/src/modules/user/controller.ts
+++ b/packages/api/src/modules/user/controller.ts
@@ -141,18 +141,17 @@ export class UserController {
         workspace,
         user,
       );
-
+      const hidden = false;
       const predicates = await new PredicateService()
         .filter({
           workspace: workspaceList,
           signer: hasSingle ? user.address : undefined,
+          hidden,
+          userId: user.id,
         })
         .paginate({ page: '0', perPage: '8' })
         .ordination({ orderBy: 'updatedAt', sort: 'DESC' })
         .list();
-
-      const inactives =
-        user.settings?.inactivesPredicates?.map(addr => addr.toLowerCase()) || [];
 
       const addHiddenFlag = (vault: Predicate): PredicateWithHidden => {
         return {
@@ -167,11 +166,14 @@ export class UserController {
         const enhancedData = predicates.data.map(addHiddenFlag);
         processedResponse = {
           ...predicates,
-          data: enhancedData.filter(vault => !vault.isHidden),
+          data: enhancedData.filter(vault => (hidden ? true : !vault.isHidden)),
         };
       } else {
         const enhancedData = predicates.map(addHiddenFlag);
-        processedResponse = enhancedData.filter(vault => !vault.isHidden);
+        processedResponse = {
+          ...predicates,
+          data: enhancedData.filter(vault => (predicates ? true : !vault.isHidden)),
+        };
       }
 
       return successful(


### PR DESCRIPTION
# Description
Hide Vaults Fix

# Summary
- [x] When hiding a vault that is on the HOME page, the next vault in the list should appear on the Home Page.
# Checklist

- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
