### PR TITLE
fix: check address type to create a new user

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,7 +38,7 @@
     "@testcontainers/postgresql": "11.0.0",
     "@ethereumjs/util": "9.0.3",
     "axios": "1.5.1",
-    "bakosafe": "0.1.10-beta.1",
+    "bakosafe": "0.1.10-beta.6",
     "body-parser": "1.20.2",
     "cheerio": "1.0.0-rc.12",
     "class-validator": "0.14.0",

--- a/packages/api/src/modules/predicate/services.ts
+++ b/packages/api/src/modules/predicate/services.ts
@@ -1,25 +1,20 @@
-import { Vault } from 'bakosafe';
+import { AddressUtils as BakoAddressUtils, DEFAULT_PREDICATE_VERSION, Vault } from 'bakosafe';
 import { Brackets, MoreThan } from 'typeorm';
 
 import { NotFound } from '@src/utils/error';
 import { IPagination, Pagination, PaginationParams } from '@src/utils/pagination';
-import { DEFAULT_PREDICATE_VERSION } from 'bakosafe';
 
 import { Predicate, TypeUser, User, Workspace } from '@models/index';
 
 import GeneralError, { ErrorTypes } from '@utils/error/GeneralError';
 import Internal from '@utils/error/Internal';
 
-import {
-  IPredicateFilterParams,
-  IPredicatePayload,
-  IPredicateService,
-} from './types';
+import { IPredicateFilterParams, IPredicatePayload, IPredicateService, } from './types';
 import { IPredicateOrdination, setOrdination } from './ordination';
 import { Network, ZeroBytes32 } from 'fuels';
 import { UserService } from '../user/service';
 import { IconUtils } from '@src/utils/icons';
-import { FuelProvider, RedisReadClient, RedisWriteClient } from '@src/utils';
+import { FuelProvider } from '@src/utils';
 import App from '@src/server/app';
 
 export class PredicateService implements IPredicateService {
@@ -75,12 +70,16 @@ export class PredicateService implements IPredicateService {
 
       for await (const member of validUsers) {
         let user = await userService.findByAddress(member);
+        let type = TypeUser.FUEL;
+        if (BakoAddressUtils.isEvm(member)) {
+          type = TypeUser.EVM;
+        }
 
         if (!user) {
           user = await userService.create({
             address: member,
             avatar: IconUtils.user(),
-            type: TypeUser.FUEL,
+            type,
             name: member,
             provider: network.url,
           });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 1.5.1
         version: 1.5.1
       bakosafe:
-        specifier: 0.1.10-beta.1
-        version: 0.1.10-beta.1(fuels@0.99.0(vitest@2.0.5(@types/node@20.6.0)))
+        specifier: 0.1.10-beta.6
+        version: 0.1.10-beta.6(fuels@0.99.0(vitest@2.0.5(@types/node@20.6.0)))
       body-parser:
         specifier: 1.20.2
         version: 1.20.2
@@ -2739,6 +2739,11 @@ packages:
     resolution: {integrity: sha512-s0gcMZ8FdCTB92WI9EOUmShkjCQrTaWoeUl3tE2oGqohjdiLBCcR+4ee95014njjtZb5lzlW2WDMAskps/W5Cg==}
     peerDependencies:
       fuels: '>=0.99.0'
+
+  bakosafe@0.1.10-beta.6:
+    resolution: {integrity: sha512-gEARZinHEX6aJmgw+4bKu0I88KtmxMrprc9Tv+WRT37mb1ICo8e5xo9bAP7U5twjFsecIOAo8aT9EsmuFd9TGw==}
+    peerDependencies:
+      fuels: ^0.101.0
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -9199,6 +9204,17 @@ snapshots:
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.27.3)
 
   bakosafe@0.1.10-beta.1(fuels@0.99.0(vitest@2.0.5(@types/node@20.6.0))):
+    dependencies:
+      '@ethereumjs/util': 9.0.3
+      '@ethersproject/bytes': 5.7.0
+      '@noble/curves': 1.9.1
+      axios: 1.5.1
+      fuels: 0.99.0(vitest@2.0.5(@types/node@20.6.0))
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - debug
+
+  bakosafe@0.1.10-beta.6(fuels@0.99.0(vitest@2.0.5(@types/node@20.6.0))):
     dependencies:
       '@ethereumjs/util': 9.0.3
       '@ethersproject/bytes': 5.7.0


### PR DESCRIPTION
# Description
When a user creates a new Vault with other evm address as a signer, when the user is not registered in Bako, is created a new user, but the type of this user is not correct, always create a with FUEL type.

# Summary
- Check address type before register a new user
