### PR TITLE
fix(middleware): add validation to avoid cases array with empty string

### DIFF
--- a/packages/api/src/middlewares/permissions/predicate.ts
+++ b/packages/api/src/middlewares/permissions/predicate.ts
@@ -85,7 +85,9 @@ export const predicatesPermissionMiddleware = (
     try {
       const predicateIds = options.predicatesSelector(req);
 
-      if (!predicateIds || predicateIds.length === 0) {
+      const validPredicateIds = predicateIds?.filter(id => id?.trim());
+
+      if (!validPredicateIds || validPredicateIds.length === 0) {
         return next();
       }
 


### PR DESCRIPTION
# Description
Fix validation in predicate permission middleware

# Summary
    - [x] Add validation to avoid cases received predicateIds as [' ']

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
