### PR TITLE
FIX: create predicate only if versions has balance

### DIFF
--- a/packages/api/src/constants/networks.ts
+++ b/packages/api/src/constants/networks.ts
@@ -3,6 +3,7 @@ export const networks: { [key: string]: string } = {
   beta4: 'https://beta-4.fuel.network/graphql',
   local: 'http://127.0.0.1:4000/v1/graphql',
   devnet: 'https://testnet.fuel.network/v1/graphql',
+  mainnet: 'https://mainnet.fuel.network/v1/graphql',
 };
 
 export const networksByChainId: { [key: string]: string } = {

--- a/packages/api/src/modules/user/service.ts
+++ b/packages/api/src/modules/user/service.ts
@@ -124,24 +124,21 @@ export class UserService implements IUserService {
         // insert a root wallet predicate
         const provider = await FuelProvider.create(payload.provider);
 
-        const { accounts: wallets, invisibleAccounts } =
-          await new PredicateService().checkOlderPredicateVersions(
-            user.address,
-            provider.url,
-          );
-
-        const network: Network = {
-          url: provider.url,
-          chainId: await provider.getChainId(),
-        };
+        const {
+          accounts: wallets,
+        } = await new PredicateService().checkOlderPredicateVersions(
+          user.address,
+          provider.url,
+        );
 
         for (const [i, wallet] of wallets.entries()) {
           const isFirst = i === 0;
           await Predicate.create({
             name: `${isFirst ? 'Personal Vault' : `Vault ${i + 1}`}`,
-            description: `${isFirst &&
+            description: `${
+              isFirst &&
               'This is your first vault. It requires a single signer (you) to execute transactions; a pattern called 1-of-1'
-              }`,
+            }`,
             predicateAddress: new Address(wallet.address).toB256(),
             configurable: JSON.stringify(wallet.configurable),
             root: isFirst,
@@ -152,7 +149,6 @@ export class UserService implements IUserService {
           }).save();
         }
 
-        user.settings.inactivesPredicates.push(...invisibleAccounts);
         await user.save();
         return user;
       })


### PR DESCRIPTION
# Description
-  Predicates should only be created if the old versions have balance.

# Summary
- Check the balance of predicate versions on the main net and test net.
- Only predicates that have old versions with balance are created.
- Remove unused code snippets.

# Checklist
- [x] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
