### PR TITLE
FIX: vaults without predicate version

### DIFF
--- a/packages/api/src/modules/predicate/services.ts
+++ b/packages/api/src/modules/predicate/services.ts
@@ -56,6 +56,7 @@ export class PredicateService implements IPredicateService {
     'p.owner',
     'p.configurable',
     'p.root',
+    'p.version',
   ];
 
   filter(filter: IPredicateFilterParams) {


### PR DESCRIPTION
# Description
In the older predicates, the predicate version is not inside the configurable object. This adjustment changes the source of the predicate version to be displayed on the Settings screen.

# Summary
- [x] Returns the version of predicate in the `PredicateService.list()` and `PredicateService.findById()`.

# Checklist
- [x] I reviewed my PR code before submitting
- [x] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
