### PR TITLE
FIX: prevent lost events by ensuring emit waits for connection and adds timeout fallback

### DIFF
--- a/packages/api/src/socket/client.ts
+++ b/packages/api/src/socket/client.ts
@@ -1,6 +1,7 @@
 import { io, Socket } from 'socket.io-client';
 import { IMessage, SocketEvents, SocketUsernames } from './types';
 
+const TIMEOUT = 8 * 1000; // 8 seconds
 export class SocketClient {
   _socket: Socket = null;
 
@@ -19,16 +20,32 @@ export class SocketClient {
   }
 
   private async _emitWhenConnected(event: string, data: any) {
-    if (this._socket.connected) {
-      this._socket.emit(event, data);
-    } else {
-      await new Promise<void>(resolve => {
-        this._socket.once('connect', () => {
+    await new Promise<void>(resolve => {
+      let resolved = false;
+
+      const resolveOnce = () => {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
           resolve();
-        });
-      });
-      this._socket.emit(event, data);
-    }
+        }
+      };
+
+      const timeout = setTimeout(() => {
+        console.warn(`Socket emit timeout for event "${event}"`);
+        resolveOnce();
+      }, TIMEOUT);
+
+      const send = () => {
+        this._socket.emit(event, data, () => resolveOnce());
+      };
+
+      if (this._socket.connected) {
+        send();
+      } else {
+        this._socket.once('connect', send);
+      }
+    });
   }
 
   // Método para enviar uma mensagem para o servidor


### PR DESCRIPTION
# Description
- Attempt to resolve the issue of the connector not responding to the `AUTH_CONFIRMED` event

# Summary
- Waits for the socket to be connected before emitting
- Resolves the promise only after receiving the server ACK or a timeout
- Prevents deadlocks by using an 8s timeout fallback

# Checklist
- [x] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
