### PR TITLE
FIX: count of pending transactions also considers transactions from vaults of which the user is a member

### DIFF
--- a/packages/api/src/modules/transaction/controller.ts
+++ b/packages/api/src/modules/transaction/controller.ts
@@ -117,6 +117,7 @@ export class TransactionController {
         // Query 2: Check if user has pending signature (only fetch resume)
         const pendingSignatureQb = Transaction.createQueryBuilder('t')
           .select(['t.id', 't.resume'])
+          .distinctOn(['t.id'])
           .innerJoin('t.predicate', 'pred')
           .leftJoin('pred.members', 'pm')
           .leftJoin('pred.owner', 'owner')
@@ -124,7 +125,8 @@ export class TransactionController {
           .andWhere('t.status = :status', {
             status: TransactionStatus.AWAIT_REQUIREMENTS,
           })
-          .andWhere(`t.network->>'chainId' = :chainId`, { chainId });
+          .andWhere(`t.network->>'chainId' = :chainId`, { chainId })
+          .orderBy('t.id', 'ASC');
 
         const transactions = await pendingSignatureQb.getMany();
 


### PR DESCRIPTION
# Description
- The number of pending signatures on the badge does not match the number of pending transactions on the list

# Summary
- Includes vault transactions where the user is the owner or a member in the count of pending transactions

# Checklist
- [x] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [x] I mentioned the PR link in the task
