### PR TITLE
FIX: add error handling when sending successful transaction emails

### DIFF
--- a/packages/api/src/modules/notification/services.ts
+++ b/packages/api/src/modules/notification/services.ts
@@ -242,6 +242,11 @@ export class NotificationService implements INotificationService {
               }).catch(e => {
                 console.error(
                   '[NOTIFICATION] Failed to send transaction success email',
+                  {
+                    to: member.email,
+                    memberId: member?.id,
+                    transactionId: summary?.transactionId,
+                  },
                   e,
                 );
               })


### PR DESCRIPTION
# Description
- When notifications were enabled, if the email notification of a successful transaction failed to send, the transaction itself also failed.

# Summary
-  Adds error handling when sending emails for successful transactions so as not to affect transaction sending

# Checklist
- [ ] I reviewed my PR code before submitting
- [ ] I ensured that the implementation is working correctly and did not impact other parts of the app
- [ ] I mentioned the PR link in the task
